### PR TITLE
:sparkles: don't use RPC on preparing template database

### DIFF
--- a/saas/README.rst
+++ b/saas/README.rst
@@ -59,6 +59,7 @@ Credits
 Contributors
 ------------
 * `Ivan Yelizariev <https://it-projects.info/team/yelizariev>`__
+* `Denis Mudarisov <https://it-projects.info/team/mudarisov>`__
 
 Sponsors
 --------

--- a/saas/__manifest__.py
+++ b/saas/__manifest__.py
@@ -7,7 +7,7 @@
     "category": "SaaS",
     # "live_test_url": "http://apps.it-projects.info/shop/product/DEMO-URL?version=12.0",
     "images": [],
-    "version": "12.0.1.0.3",
+    "version": "12.0.2.0.0",
     "application": False,
 
     "author": "IT-Projects LLC, Ivan Yelizariev",

--- a/saas/doc/changelog.rst
+++ b/saas/doc/changelog.rst
@@ -1,3 +1,8 @@
+`2.0.0`
+-------
+
+- **New:** don't use RPC on preparing template database -- SaaS Operator must provide it's own way to access to the database
+
 `1.0.3`
 -------
 

--- a/saas/models/saas_db.py
+++ b/saas/models/saas_db.py
@@ -22,10 +22,10 @@ class SAASDB(models.Model):
 
     @api.multi
     @job
-    def create_db(self, template_db, demo, password=None, lang='en_US', callback_obj=None, callback_method=None):
+    def create_db(self, template_db, demo, lang='en_US', callback_obj=None, callback_method=None):
         self.ensure_one()
         db_name = self.name
-        self.operator_id._create_db(template_db, db_name, demo, password, lang)
+        self.operator_id._create_db(template_db, db_name, demo, lang)
         self.state = 'done'
         self.env['saas.log'].log_db_created(self)
         if callback_obj and callback_method:

--- a/saas/models/saas_operator.py
+++ b/saas/models/saas_operator.py
@@ -4,10 +4,12 @@
 from collections import defaultdict
 import string
 
-from odoo import models, fields, api, tools, SUPERUSER_ID
+from odoo import models, fields, api, tools, SUPERUSER_ID, sql_db, registry
 from odoo.service import db
 from odoo.service.model import execute
 from odoo.addons.queue_job.job import job
+
+MANDATORY_MODULES = ['auth_quick']
 
 
 class SAASOperator(models.Model):
@@ -27,7 +29,7 @@ class SAASOperator(models.Model):
     template_operator_ids = fields.One2many('saas.template.operator', 'operator_id')
 
     @api.multi
-    def _create_db(self, template_db, db_name, demo, password=None, lang='en_US'):
+    def _create_db(self, template_db, db_name, demo, lang='en_US'):
         """Synchronous db creation"""
         if self.type == 'local':
             # to avoid installing extra modules we need this condition
@@ -48,7 +50,7 @@ class SAASOperator(models.Model):
                 db.exp_duplicate_database(template_db, db_name)
             else:
                 db.exp_create_database(
-                    db_name, demo, lang, user_password=password)
+                    db_name, demo, lang)
 
         if test_enable:
             tools.config['test_enable'] = test_enable
@@ -60,6 +62,39 @@ class SAASOperator(models.Model):
                 continue
 
             db.exp_drop(db_name)
+
+    @job
+    def install_modules(self, template_id, template_operator_id):
+        self.ensure_one()
+        modules = [module.name for module in template_id.template_module_ids]
+        modules = [('name', 'in', MANDATORY_MODULES + modules)]
+        if self.type == 'local':
+            db = sql_db.db_connect(template_operator_id.operator_db_name)
+            with api.Environment.manage(), db.cursor() as cr:
+                env = api.Environment(cr, SUPERUSER_ID, {})
+                module_ids = env['ir.module.module'].search([('state', '=', 'uninstalled')] + modules)
+                module_ids.button_immediate_install()
+                # Some magic to force reloading registry in other workers
+                env.registry.registry_invalidated = True
+                env.registry.signal_changes()
+                template_operator_id.state = 'post_init'
+                self.with_delay().post_init(template_id, template_operator_id)
+
+    @job
+    def post_init(self, template_id, template_operator_id):
+        if self.type == 'local':
+            db = sql_db.db_connect(template_operator_id.operator_db_name)
+            registry(template_operator_id.operator_db_name).check_signaling()
+            with api.Environment.manage(), db.cursor() as cr:
+                env = api.Environment(cr, SUPERUSER_ID, {})
+                action = env['ir.actions.server'].create({
+                    'name': 'Local Code Eval',
+                    'state': 'code',
+                    'model_id': 1,
+                    'code': template_id.template_post_init
+                })
+                action.run()
+            template_operator_id.state = 'done'
 
     def get_db_url(self, db):
         # TODO: use mako for url templating


### PR DESCRIPTION
Since we no longer use RPC, therefore we no longer need to pass password when creating templates.
Now authentication is performed using a token.