### PR TITLE
[FIX]signup_error caused by missing params

### DIFF
--- a/saas_apps_signup/controllers/auth_signup.py
+++ b/saas_apps_signup/controllers/auth_signup.py
@@ -14,6 +14,7 @@ _logger = logging.getLogger(__name__)
 class Main(SignupVerifyEmail):
     def get_auth_signup_qcontext(self):
         d = super(Main, self).get_auth_signup_qcontext()
+        d.update(request.params)
         try_now_args = ("installing_modules", "max_users_limit", "period")
 
         if any([k in d for k in try_now_args]):


### PR DESCRIPTION
When signing up new user from frontend, the below error is prompted, the same issue mentioned in #126 :
```ERROR main_saas odoo.addons.auth_signup_verify_email.controllers.main: 'operator_id'
Traceback (most recent call last):
File "/odoo14/custom/saas/auth_signup_verify_email/controllers/main.py", line 59, in passwordless_signup
sudo_users.signup(values, qcontext.get("token"))
File "/odoo14/custom/saas/saas_apps_signup/models/res_users.py", line 31, in signup
return self.signup_to_try(values, *args, **kwargs)
File "/odoo14/custom/saas/saas_apps_signup/models/res_users.py", line 43, in signup_to_try
operator_id = int(values.pop("operator_id"))
KeyError: 'operator_id'```